### PR TITLE
Add `changelog_uri` to gemspec metadata

### DIFF
--- a/tsort.gemspec
+++ b/tsort.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |spec|
 
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["source_code_uri"] = spec.homepage
+  spec.metadata["changelog_uri"] = "#{spec.homepage}/releases"
 
   dir, gemspec = File.split(__FILE__)
   excludes = %W[


### PR DESCRIPTION
Adds a link to the GitHub Releases page for this gem consistent with other gems in the Ruby organization. Existing examples include:

- [json](https://github.com/ruby/json/blob/master/json.gemspec)
- [ostruct](https://github.com/ruby/ostruct/blob/master/ostruct.gemspec)